### PR TITLE
Update ParseMarkdown.php

### DIFF
--- a/src/Markdown/Process/ParseMarkdown.php
+++ b/src/Markdown/Process/ParseMarkdown.php
@@ -8,6 +8,10 @@ class ParseMarkdown
 {
     private mixed $breaksEnabled;
 
+    protected bool $setBreaksEnabled = false;
+    protected bool $setUrlsLinked = false;
+    protected bool $setMarkupEscaped = false;
+
     protected bool $safeMode;
 
     protected mixed $markupEscaped;


### PR DESCRIPTION
PHP 8.3 "Creation of dynamic property id deprecated" problems fixed.