### PR TITLE
Update toHtml method return type and docblock

### DIFF
--- a/src/Markdown.php
+++ b/src/Markdown.php
@@ -174,9 +174,9 @@ final class Markdown
     /**
      * Compile Markdown to Raw HTML Output
      *
-     * @return string|null|\LogicException
+     * @throws \LogicException
      */
-    public function toHtml(): \LogicException|string|null
+    public function toHtml(): ?string
     {
         if (!isset($this->contents) || count($this->contents) == 0) {
             throw new \LogicException(


### PR DESCRIPTION
This PR fixes `toHtml`'s docblock of the return types.

Method `toHtml` had `@return string|null|\LogicException` in the PHPDoc, but an instance of `LogicException` is never returned, only thrown when a certain situation occurs. Also duplicating return values in PHPDoc as well as in the code might lead to outdated code.

The current situation confuses PHPStan and one must add custom PHPDoc to "force" a certain behavior.